### PR TITLE
correction for the bug due to the name of the function end()

### DIFF
--- a/src/telemetry/c/framing.c
+++ b/src/telemetry/c/framing.c
@@ -54,7 +54,7 @@ void outgoing_storage(uint8_t * buf, uint32_t bufSize)
   outgoingStorage.size = bufSize;
 }
 
-void begin()
+void begin_frame()
 {
   if(outgoingStorage.size == 0 || outgoingStorage.ptr == NULL)
     return;
@@ -97,7 +97,7 @@ void append4(uint32_t fourbytes)
   append(ptr[3]);
 }
 
-uint32_t end()
+uint32_t end_frame()
 {
   if(outgoingStorage.size == 0 || outgoingStorage.ptr == NULL)
     return 0;

--- a/src/telemetry/c/telemetry_core.c
+++ b/src/telemetry/c/telemetry_core.c
@@ -192,7 +192,7 @@ uint16_t payload(const void * p, uint32_t size, uint16_t crc)
 void frame(const char * t, TM_type type, const void * data, uint32_t datasize)
 {
   // start new frame
-  begin();
+  begin_frame();
 
   // header
   uint16_t crc = header(type);
@@ -207,7 +207,7 @@ void frame(const char * t, TM_type type, const void * data, uint32_t datasize)
   append2(crc);
 
   // complete frame
-  uint32_t bytesAmount = end();
+  uint32_t bytesAmount = end_frame();
 
   // send data
   send(outgoingBuffer, bytesAmount);

--- a/src/telemetry/headers/framing.h
+++ b/src/telemetry/headers/framing.h
@@ -9,11 +9,11 @@ void initialize_framing();
 // Set storage for the outgoing frame
 void outgoing_storage(uint8_t * buf, uint32_t bufSize);
 
-void begin();
+void begin_frame();
 void append(uint8_t byte);
 void append2(uint16_t twobytes);
 void append4(uint32_t fourbytes);
-uint32_t end();
+uint32_t end_frame();
 
 // Incoming data
 // Set storage for the incoming data

--- a/test/c/framing_outgoing_suite.c
+++ b/test/c/framing_outgoing_suite.c
@@ -8,9 +8,9 @@ TEST framing_simple_frame()
   initialize_framing();
   outgoing_storage(outgoingBuffer,12);
 
-  begin();
+  begin_frame();
   append(0xFF);
-  uint32_t amount = end();
+  uint32_t amount = end_frame();
 
   ASSERT_EQ_FMT(3,amount,"%d");
 
@@ -33,11 +33,11 @@ TEST framing_with_escaping()
   initialize_framing();
   outgoing_storage(outgoingBuffer,12);
 
-  begin();
+  begin_frame();
   append(0xF7);
   append(0x7F);
   append(0x7D);
-  uint32_t amount = end();
+  uint32_t amount = end_frame();
 
   ASSERT_EQ_FMT(8,amount,"%d");
 
@@ -59,10 +59,10 @@ TEST framing_overflow()
   initialize_framing();
   outgoing_storage(outgoingBuffer,3);
 
-  begin();
+  begin_frame();
   append(0xFF);
   append(0xFF);
-  uint32_t amount = end();
+  uint32_t amount = end_frame();
 
   ASSERT_EQ_FMT(0,amount,"%d");
 


### PR DESCRIPTION
This is the pull request solving the issues #61  "publish error in "end()" function".
Juste rename the begin() and end() function to begin_frame() and end_frame().