### PR TITLE
Possible memory leak fix

### DIFF
--- a/src/telemetry/c/dictionnary.c
+++ b/src/telemetry/c/dictionnary.c
@@ -69,7 +69,10 @@ struct nlist * install(struct nlist ** hashtab, const char * key, void * ptr, pt
 
         // If allocation failed
         if (np == NULL || (np->key = strdup(key)) == NULL)
+        {
+          free(np);  
           return NULL;
+        }
 
         init_entry(np);
 


### PR DESCRIPTION
If allocation for strdup(key) failed, then np will not be released.
A memory leak could occur.